### PR TITLE
Fixed the roof material definition which set a normal map texture for its ambient texture

### DIFF
--- a/sponza.mtl
+++ b/sponza.mtl
@@ -267,7 +267,7 @@ d 0.000000
 illum 2
 map_Kd textures/sponza_roof_diff.tga
 map_Ka textures/sponza_roof_diff.tga
-map_Ka textures/sponza_roof_ddn.tga
+map_Disp textures/sponza_roof_ddn.tga
 
 newmtl vase
 Ns 7.843137


### PR DESCRIPTION
Fixed the roof material definition. It previously had its ambient texture (map_Ka) specified twice, with the second time erroneously setting the roof's ambient texture to the roof's normal map texture.

Updated the material such that the roof's normal texture is now specified as map_Disp, matching the standard used in other materials. For example, see the 'vase' material, 'leaf' material, or any others than similarly specify normal map with map_Disp.

May not have been noticed by other users depending on which of the material's multiple ambient textures specifications your renderer defaulted to using, whether or not you looked at how the roof rendered from above, and whether or not your renderer had proper ambient lighting contributions set up.